### PR TITLE
Update soda.vim

### DIFF
--- a/colors/soda.vim
+++ b/colors/soda.vim
@@ -10,7 +10,7 @@ if exists("syntax_on")
   syntax reset
 endif
 
-let g:colors_name = "Espresso Soda"
+let g:colors_name = "soda"
 
 hi Cursor ctermfg=NONE ctermbg=59 cterm=NONE guifg=NONE guibg=#615649 gui=NONE
 hi Visual ctermfg=NONE ctermbg=153 cterm=NONE guifg=NONE guibg=#c2e8ff gui=NONE


### PR DESCRIPTION
Prevent error when vim tries to reload the current colour scheme and can't find 'Espresso Soda'.

I think this is the right fix...